### PR TITLE
[Fix] domain entity 수정 및 필드 추가

### DIFF
--- a/src/main/java/org/yeolmae/challenge/domain/Badge.java
+++ b/src/main/java/org/yeolmae/challenge/domain/Badge.java
@@ -1,5 +1,5 @@
 package org.yeolmae.challenge.domain;
 
-public enum Level {
+public enum Badge {
     BRONZE, SILVER, GOLD, DIAMOND
 }

--- a/src/main/java/org/yeolmae/challenge/domain/Challenge.java
+++ b/src/main/java/org/yeolmae/challenge/domain/Challenge.java
@@ -14,32 +14,36 @@ public class Challenge {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int challenge_id;
+    @Column(name = "id")
+    private int id;
 
-    @Column(nullable = false)
+    @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(name = "writer", nullable = false)
     private String writer;
 
-    @Column(nullable = false)
+    @Column(name = "content", nullable = false, length = 500)
     private String content;
 
-    @Column(updatable = false)
-    private LocalDate register_date;
+    @Column(name = "registerDate", updatable = false, nullable = false)
+    private LocalDate registerDate;
 
-    @Column(nullable = false)
-    private LocalDate start_date;
+    @Column(name = "startDate", nullable = false)
+    private LocalDate startDate;
 
-    @Column(nullable = false)
-    private LocalDate end_date;
+    @Column(name = "endDate", nullable = false)
+    private LocalDate endDate;
 
     public void update(String title, String writer, String content, LocalDate start_date, LocalDate end_date) {
         this.title = title;
         this.writer = writer;
         this.content = content;
-        this.start_date = start_date;
-        this.end_date = end_date;
+        this.startDate = start_date;
+        this.endDate = end_date;
     }
+
+    @OneToOne
+    private History history;
 
 }

--- a/src/main/java/org/yeolmae/challenge/domain/ChallengeImage.java
+++ b/src/main/java/org/yeolmae/challenge/domain/ChallengeImage.java
@@ -1,0 +1,23 @@
+package org.yeolmae.challenge.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class ChallengeImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private int id;
+
+    @ManyToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "challengeId", referencedColumnName = "id")
+    Challenge challenge;
+
+    @Column(name = "image_detail", length = 500)
+    private String image_detail;
+
+    @Column(name = "image_thumb", nullable = false, length = 500)
+    private String image_thumb;
+
+}

--- a/src/main/java/org/yeolmae/challenge/domain/History.java
+++ b/src/main/java/org/yeolmae/challenge/domain/History.java
@@ -1,0 +1,31 @@
+package org.yeolmae.challenge.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "history")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class History {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private int id;
+
+    @ManyToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "memberId", referencedColumnName = "id", nullable = false)
+    private Member member;
+
+    @OneToOne
+    @JoinColumn(name = "Id")
+    private Challenge challenge;
+
+    @Column(name = "success")
+    private boolean success;
+
+}

--- a/src/main/java/org/yeolmae/challenge/domain/Member.java
+++ b/src/main/java/org/yeolmae/challenge/domain/Member.java
@@ -18,20 +18,25 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private String pw;
 
+    @Column(nullable = false)
     private String nickname;
 
-//    @ElementCollection(fetch = FetchType.LAZY)
-//    @Builder.Default
-//    private Set<Level> level = new HashSet<>();
-//
-//    @ElementCollection(fetch = FetchType.LAZY)
-//    @Builder.Default
-//    private Set<MemberRole> roleSet = new HashSet<>();
+    @Column(nullable = false)
+    private int level;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Builder.Default
+    private Set<Badge> badge = new HashSet<>();
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Builder.Default
+    private Set<MemberRole> roleSet = new HashSet<>();
 
     public void changePassword(String pw) {
         this.pw = pw;

--- a/src/main/java/org/yeolmae/challenge/service/ChallengeService.java
+++ b/src/main/java/org/yeolmae/challenge/service/ChallengeService.java
@@ -27,21 +27,21 @@ public class ChallengeService {
                 .title(request.getTitle())
                 .writer(request.getWriter())
                 .content(request.getContent())
-                .register_date(request.getRegister_date())
-                .start_date(request.getStart_date())
-                .end_date(request.getEnd_date())
+                .registerDate(request.getRegister_date())
+                .startDate(request.getStart_date())
+                .endDate(request.getEnd_date())
                 .build();
 
         Challenge savedChallenge = challengeRepository.save(challenge);
 
         return new CreateChallengeResponse(
-                savedChallenge.getChallenge_id(),
+                savedChallenge.getId(),
                 savedChallenge.getTitle(),
                 savedChallenge.getWriter(),
                 savedChallenge.getContent(),
-                savedChallenge.getRegister_date(),
-                savedChallenge.getStart_date(),
-                savedChallenge.getEnd_date()
+                savedChallenge.getRegisterDate(),
+                savedChallenge.getStartDate(),
+                savedChallenge.getEndDate()
         );
     }
 
@@ -54,18 +54,18 @@ public class ChallengeService {
         foundChallenge.update(request.getTitle(), request.getWriter(), request.getContent(),
                 request.getStart_date(), request.getEnd_date());
 
-        return new UpdateChallengeResponse(foundChallenge.getChallenge_id(), foundChallenge.getTitle(), foundChallenge.getWriter(),
-                foundChallenge.getContent(), foundChallenge.getRegister_date(), foundChallenge.getStart_date(),
-                foundChallenge.getEnd_date());
+        return new UpdateChallengeResponse(foundChallenge.getId(), foundChallenge.getTitle(), foundChallenge.getWriter(),
+                foundChallenge.getContent(), foundChallenge.getRegisterDate(), foundChallenge.getStartDate(),
+                foundChallenge.getEndDate());
     }
 
     public Page<ReadChallengeResponse> readAllChallenge(Pageable pageable) {
 
         Page<Challenge> challengePage = challengeRepository.findAll(pageable);
 
-        return challengePage.map(challenge -> new ReadChallengeResponse(challenge.getChallenge_id(), challenge.getTitle(),
-                challenge.getWriter(), challenge.getContent(), challenge.getRegister_date(), challenge.getStart_date(),
-                challenge.getEnd_date()));
+        return challengePage.map(challenge -> new ReadChallengeResponse(challenge.getId(), challenge.getTitle(),
+                challenge.getWriter(), challenge.getContent(), challenge.getRegisterDate(), challenge.getStartDate(),
+                challenge.getEndDate()));
     }
 
     @Transactional
@@ -76,8 +76,8 @@ public class ChallengeService {
 
         challengeRepository.delete(challenge);
 
-        return new DeleteChallengeResponse(challenge.getChallenge_id(), challenge.getTitle(), challenge.getWriter(),
-                challenge.getContent(), challenge.getRegister_date(), challenge.getStart_date(), challenge.getEnd_date());
+        return new DeleteChallengeResponse(challenge.getId(), challenge.getTitle(), challenge.getWriter(),
+                challenge.getContent(), challenge.getRegisterDate(), challenge.getStartDate(), challenge.getEndDate());
     }
 
     public ReadChallengeResponse readChallengeById(Integer challenge_id) {
@@ -85,9 +85,9 @@ public class ChallengeService {
         Challenge foundChallenge = challengeRepository.findById(challenge_id)
                 .orElseThrow(() -> new EntityNotFoundException("해당 challenge_id로 조회된 게시글이 없습니다."));
 
-        return new ReadChallengeResponse(foundChallenge.getChallenge_id(), foundChallenge.getTitle(), foundChallenge.getWriter(),
-                foundChallenge.getContent(), foundChallenge.getRegister_date(), foundChallenge.getStart_date(),
-                foundChallenge.getEnd_date());
+        return new ReadChallengeResponse(foundChallenge.getId(), foundChallenge.getTitle(), foundChallenge.getWriter(),
+                foundChallenge.getContent(), foundChallenge.getRegisterDate(), foundChallenge.getStartDate(),
+                foundChallenge.getEndDate());
     }
 
 }


### PR DESCRIPTION
## 기능설명
domain entity 수정 및 필드 추가


## 주요 작업 내용
- 회원데이터 내 badge와 level 개념 다시 적용
- Member 엔티티 < 기존에 누락된 level 필드 추가
- History, ChallengeImage 테이블 추가
- 주요 필드 nullable = false 처리
- FK, @OneToOne, @ManyToOne 처리


## 비고(To Reviewers :pray:)
- @thdrkfka  Member 엔티티 병합 시 내용 확인 필요
- 변경된 필드 변수명은 해당 브랜치 병합 후 일괄 수정 예정 ([fix] Service 변수명 수정)
- 어플리케이션 재실행 전 !!!!반드시(중요)!!!!! mysql 내 테이블 모두 drop 필요*****