### PR TITLE
[Feat] User Reply(댓글) 이미지 파일 업로드

### DIFF
--- a/src/main/java/org/yeolmae/challenge/domain/Reply.java
+++ b/src/main/java/org/yeolmae/challenge/domain/Reply.java
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.persistence.*;
 
 @Entity
@@ -14,7 +17,7 @@ import jakarta.persistence.*;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = "challenge")
+@ToString(exclude = "imageSet")
 public class Reply {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,6 +40,31 @@ public class Reply {
 
     public void changeReply(String text) {
         this.replyText = text;
+    }
+
+    @OneToMany(mappedBy = "reply", // ReplyImage의 reply 변수
+            cascade = {CascadeType.ALL},
+            fetch = FetchType.EAGER,
+            orphanRemoval = true
+    )
+    @Builder.Default
+    private Set<ReplyImage> imageSet = new HashSet<>();
+
+    public void addImage(String uuid, String fileName) {
+
+        ReplyImage replyImage = ReplyImage.builder()
+                .uuid(uuid)
+                .fileName(fileName)
+                .reply(this)
+                .ord(imageSet.size())
+                .build();
+        imageSet.add(replyImage);
+    }
+
+    public void clearImage() {
+
+        imageSet.forEach(replyImage -> replyImage.changeReply(null));
+        this.imageSet.clear();
     }
 
 }

--- a/src/main/java/org/yeolmae/challenge/domain/ReplyImage.java
+++ b/src/main/java/org/yeolmae/challenge/domain/ReplyImage.java
@@ -1,0 +1,34 @@
+package org.yeolmae.challenge.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString(exclude = "reply")
+public class ReplyImage implements Comparable<ReplyImage> {
+
+    @Id
+    private String uuid;
+
+    private String fileName;
+
+    private int ord;
+
+    @ManyToOne
+    private Reply reply;
+
+    @Override
+    public int compareTo(ReplyImage other) {
+        return this.ord - other.ord;
+    }
+
+    public void changeReply(Reply reply) {
+        this.reply = reply;
+    }
+}

--- a/src/main/java/org/yeolmae/challenge/repository/ReplyRepository.java
+++ b/src/main/java/org/yeolmae/challenge/repository/ReplyRepository.java
@@ -2,14 +2,21 @@ package org.yeolmae.challenge.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.yeolmae.challenge.domain.Reply;
 
+import java.util.Optional;
+
 public interface ReplyRepository extends JpaRepository<Reply, Integer> {
 
     @Query("select r from Reply r where r.challenge.id = :challengeId")
     Page<Reply> listOfReplies(@Param("challengeId") Integer challengeId, Pageable pageable);
- 
+
+    @EntityGraph(attributePaths = {"imageSet"})
+    @Query("select r from Reply r where r.rno = :rno")
+    Optional<Reply> findByIdWithImage(@Param("rno") Integer rno);
+
 }


### PR DESCRIPTION
## 기능 요약
User Reply(댓글) 이미지 파일 업로드


## 주요 작업 내용
- Reply 엔티티 내 addImage, clearImage 메소드, imageSet 필드 추가
- ReplyImage 엔티티 객체 추가
- ReplyRepository 내 findByIdWithImage 메소드 추가

## 비고(To Reviewers :pray:)
- 댓글에 이미지를 작은 썸네일로 등록하는 기능입니다.
